### PR TITLE
setInterval returns a NodeJS.Timeout, not a NodeJS.Timer

### DIFF
--- a/templates/_restart.ejs
+++ b/templates/_restart.ejs
@@ -6,7 +6,7 @@ const reconnect = {
 // <%= options.mongodb ? 'mongodb' : 'postgres' %> client
 const <%= options.mongodb ? 'mongo' : 'postgres' %> = {
 <% } -%>
-  interval: null<% if (options.typescript) { %> as NodeJS.Timer | null<% } %>,
+  interval: null<% if (options.typescript) { %> as NodeJS.Timeout | null<% } %>,
 <% if (options.typescript && options.redis) { -%>
   connect: null as Function | null,
   disconnect: null as Function | null,


### PR DESCRIPTION
Current code results in TypeScript type error `Argument of type 'Timer' is not assignable to parameter of type 'number'` in call to `clearInterval`